### PR TITLE
Fix variable issue

### DIFF
--- a/strings/en/bugreport.json
+++ b/strings/en/bugreport.json
@@ -10,7 +10,7 @@
         },
         {
           "title": "How do I take a logcat?",
-          "content": "For non-root users:\nYou will need a PC to take `logcat` outputs. Here is a [text guide](https://github.com/YTVanced/Vanced#creating-a-logcat-using-the-android-debug-bridge-adb-on-your-pc) and a [video guide](https://youtu.be/ICLpwgsJJP0).\n\nFor root users:\nYou don't need a PC for this. You can follow the instructions in [here](https://github.com/YTVanced/Vanced#creating-a-logcat-using-termux-on-your-rooted-android)."
+          "content": "For non-root users:\nYou will need a PC to take `logcat` outputs. Here is a [text guide](https://github.com/YTVanced/Vanced#creating-a-logcat-using-the-android-debug-bridge-adb-on-your-pc) and a [video guide](https://youtu.be/ICLpwgsJJP0).\n\nFor root users:\nYou don't need a PC for this. You can follow the instructions [in here](https://github.com/YTVanced/Vanced#creating-a-logcat-using-termux-on-your-rooted-android)."
         },
         {
           "title": "Your bug is UI related?",


### PR DESCRIPTION
Seems like Crowdin sees \[here] expression as variable

![image](https://user-images.githubusercontent.com/5789670/107859853-63c00d80-6e4d-11eb-9fb9-c9885de2b52d.png)
